### PR TITLE
Update signout events for sockets

### DIFF
--- a/lib/chat_api/account.ex
+++ b/lib/chat_api/account.ex
@@ -429,10 +429,4 @@ defmodule ChatApi.Account do
       {:error, _changes, _error, _change_atoms} -> {:error, :invalid_token}
     end
   end
-
-  def user_logged_in?(user_id) do
-    query = UserToken.active_user_tokens_for_context_token(user_id, :refresh)
-    num_tokens = Repo.all(query)
-    length(num_tokens) > 0
-  end
 end

--- a/lib/chat_api/account.ex
+++ b/lib/chat_api/account.ex
@@ -399,4 +399,40 @@ defmodule ChatApi.Account do
       {:ok, changes} -> {:ok, changes[:update_changeset]}
     end
   end
+
+  @doc """
+  Removes a specified refresh token for the user
+  """
+  @spec sign_out(String.t(), String.t()) ::
+          {:ok, :signed_out} | {:error, :invalid_token}
+  def sign_out(user_id, token) do
+    transaction =
+      Ecto.Multi.new()
+      |> Ecto.Multi.run(:verify_token, fn _repo, _changesets ->
+        case UserToken.verify_hashed_token(token, :refresh) do
+          {:ok, user, token} when user.id == user_id ->
+            {:ok, token.token}
+
+          _ ->
+            {:error, :invalid_token}
+        end
+      end)
+      |> Ecto.Multi.run(:delete_token, fn _repo, %{verify_token: hashed_token} ->
+        case Repo.delete_all(UserToken.user_token_query(user_id, hashed_token)) do
+          {1, _} -> {:ok, :deleted}
+          _ -> {:error, :unable_to_delete}
+        end
+      end)
+
+    case Repo.transaction(transaction) do
+      {:ok, _} -> {:ok, :signed_out}
+      {:error, _changes, _error, _change_atoms} -> {:error, :invalid_token}
+    end
+  end
+
+  def user_logged_in?(user_id) do
+    query = UserToken.active_user_tokens_for_context_token(user_id, :refresh)
+    num_tokens = Repo.all(query)
+    length(num_tokens) > 0
+  end
 end

--- a/lib/chat_api/account/user_tokens.ex
+++ b/lib/chat_api/account/user_tokens.ex
@@ -65,8 +65,8 @@ defmodule ChatApi.Account.UserToken do
 
   The authorization token itself cannot be revoked, but it only has a lifespan of 30 minutes.
   """
-  @spec get_active_user_tokens_for_context(String.t(), token_type()) :: Ecto.Query.t()
-  def get_active_user_tokens_for_context(user_id, context) do
+  @spec active_user_tokens_for_context_token(String.t(), token_type()) :: Ecto.Query.t()
+  def active_user_tokens_for_context_token(user_id, context) do
     lifespan = token_lifespan_for_context(context)
 
     from(t in UserToken,

--- a/lib/chat_api_web/channels/system_channel.ex
+++ b/lib/chat_api_web/channels/system_channel.ex
@@ -23,12 +23,6 @@ defmodule ChatApiWeb.SystemChannel do
   end
 
   @impl true
-  def terminate({:shutdown, _}, _socket) do
-    send(self(), :check_user)
-    :ok
-  end
-
-  @impl true
   def handle_info(:track_user, socket) do
     if socket.assigns.hidden do
       :ok = remove_user_id_from_presence(socket)
@@ -37,15 +31,6 @@ defmodule ChatApiWeb.SystemChannel do
     end
 
     push(socket, "presence_state", Presence.list(socket))
-    {:noreply, socket}
-  end
-
-  @impl true
-  def handle_info(:check_user, socket) do
-    if !Account.user_logged_in?(socket.assigns.user_id) do
-      remove_user_id_from_presence(socket)
-    end
-
     {:noreply, socket}
   end
 
@@ -120,21 +105,6 @@ defmodule ChatApiWeb.SystemChannel do
       end
     else
       {:reply, {:error, :invalid_token}, socket}
-    end
-  end
-
-  def handle_in("signout", %{"token" => token, "refresh_token" => refresh_token}, socket) do
-    if UserSocket.authorized?(socket, token) do
-      case Account.sign_out(socket.assigns.user_id, refresh_token) do
-        {:ok, :signed_out} ->
-          send(self(), :check_user)
-          {:noreply, socket}
-
-        _ ->
-          {:reply, {:error, :invalid_token}, socket}
-      end
-    else
-      {:reply, {:error, :unauthorized}, socket}
     end
   end
 

--- a/lib/chat_api_web/controllers/profile_controller.ex
+++ b/lib/chat_api_web/controllers/profile_controller.ex
@@ -83,4 +83,10 @@ defmodule ChatApiWeb.ProfileController do
       render(conn, :update_profile, profile: profile)
     end
   end
+
+  def signout(%Plug.Conn{assigns: %{user_id: user_id}} = conn, %{"token" => token}) do
+    with {:ok, :signed_out} <- Account.sign_out(user_id, token) do
+      AuthController.send_204(conn)
+    end
+  end
 end

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -1,4 +1,5 @@
 defmodule ChatApiWeb.Router do
+  alias ChatApiWeb.ProfileController
   use ChatApiWeb, :router
 
   # NEVER EVER ALIAS YOUR CONTROLLERS IN THIS FILE
@@ -25,6 +26,7 @@ defmodule ChatApiWeb.Router do
 
   scope "/api", ChatApiWeb do
     pipe_through(:api)
+    post("/signout", ProfileController, :signout)
     post("/signout_all", ProfileController, :signout_all)
     post("/token/email_confirm", ProfileController, :request_new_confirmation_token)
     post("/token/email_change", ProfileController, :request_email_change_token)

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -1,5 +1,6 @@
 defmodule ChatApiWeb.Router do
   # NEVER EVER ALIAS YOUR CONTROLLERS IN THIS FILE
+  # Your IDE might do it automatically - BE CAREFUL
   use ChatApiWeb, :router
 
   pipeline :api do

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -1,8 +1,6 @@
 defmodule ChatApiWeb.Router do
-  alias ChatApiWeb.ProfileController
-  use ChatApiWeb, :router
-
   # NEVER EVER ALIAS YOUR CONTROLLERS IN THIS FILE
+  use ChatApiWeb, :router
 
   pipeline :api do
     plug(:accepts, ["json"])


### PR DESCRIPTION
Closes GH-5

## Changes
* Add `sign_out` function to `ChatApi.Account` module
* Add `/api/signout` API route to delete token
* Rename `get_active_user_tokens_for_context` function in `ChatApi.Account.UserToken` to `active_user_tokens_for_context_query` to follow convention
